### PR TITLE
Accept fill texture embed (ByteString)

### DIFF
--- a/gelatin-core/gelatin-core.cabal
+++ b/gelatin-core/gelatin-core.cabal
@@ -29,6 +29,7 @@ library
                        Gelatin.Core
   other-extensions:    MultiParamTypeClasses, FlexibleInstances
   build-depends:       base       >=4.8 && <4.9,
+                       bytestring,
                        linear     >= 1.20 && < 1.21,
                        hashable   >= 1.2 && < 1.3,
                        containers >= 0.5 && < 0.6

--- a/gelatin-core/src/Gelatin/Core/Fill.hs
+++ b/gelatin-core/src/Gelatin/Core/Fill.hs
@@ -9,31 +9,42 @@ module Gelatin.Core.Fill (
 import Gelatin.Core.Color
 import Gelatin.Core.Bounds
 import Gelatin.Core.Transform
+import Data.ByteString (ByteString)
 import Data.Hashable
 import qualified Data.Map.Strict as M
 import Data.Map (Map)
 import Data.List (sortBy, sort)
 import GHC.Generics
 import Linear
+
+
 --------------------------------------------------------------------------------
 -- Types
 --------------------------------------------------------------------------------
+
 data Fill = FillColor (V2 Float -> V4 Float)
-          | FillTexture FilePath (V2 Float -> V2 Float)
+          | FillTexture ByteString (V2 Float -> V2 Float)
+          | FillTextureFile FilePath (V2 Float -> V2 Float)
 
 data FillHash = FillHash Fill [V2 Float]
 
 instance Hashable FillHash where
     hashWithSalt s (FillHash (FillColor f) vs) =
         s `hashWithSalt` "FillColor" `hashWithSalt` map f vs
-    hashWithSalt s (FillHash (FillTexture fp f) vs) =
-        s `hashWithSalt` "FillTexture" `hashWithSalt` fp `hashWithSalt` map f vs
+    hashWithSalt s (FillHash (FillTexture bstr f) vs) =
+        s `hashWithSalt` "FillTexture" `hashWithSalt` bstr `hashWithSalt` map f vs
+    hashWithSalt s (FillHash (FillTextureFile fp f) vs) =
+        s `hashWithSalt` "FillTextureFile" `hashWithSalt` fp `hashWithSalt` map f vs
 
 instance Show Fill where
     show (FillColor _) = "FillColor{ V2 Float -> V4 Float }"
-    show (FillTexture fp _) = "FillTexture{ " ++ fp ++ " (V2 Float -> V2 Float) }"
+    show (FillTexture _ _) = "FillTexture{ <embed> (V2 Float -> V2 Float) }"
+    show (FillTextureFile fp _) = "FillTexture{ " ++ fp ++ " (V2 Float -> V2 Float) }"
+
+
 --------------------------------------------------------------------------------
 -- Smart constructors
 --------------------------------------------------------------------------------
+
 solid :: Color -> Fill
-solid = FillColor . const 
+solid = FillColor . const

--- a/gelatin-example/gelatin-example.cabal
+++ b/gelatin-example/gelatin-example.cabal
@@ -31,7 +31,7 @@ executable gelatin-example
                      , linear
                      , hashable
                      , bytestring
---                     , file-embed
+                     , file-embed
   default-language:    Haskell2010
 
 source-repository head

--- a/gelatin-example/src/Main.hs
+++ b/gelatin-example/src/Main.hs
@@ -2,7 +2,7 @@
 
 import           Control.Concurrent     (threadDelay)
 import           Control.Monad          (when)
-import qualified Data.ByteString
+import           Data.ByteString        (ByteString)
 import           Data.ByteString.Lazy   (fromStrict)
 import           Data.FileEmbed         (embedFile)
 import           Graphics.Text.TrueType (decodeFont)
@@ -16,11 +16,11 @@ import           Gelatin.SDL2
 
 
 ttfFont, jpgTex :: Data.ByteString.ByteString
-ttfFont = $(embedFile "./assets/Neuton-Regular.ttf")
-jpgTex  = $(embedFile "./assets/tex.jpg")
+ttfFont = $(embedFile $ "assets" </> "Neuton-Regular.ttf")
+jpgTex  = $(embedFile $ "assets" </> "tex.jpg")
 
-picture :: FontData -> Picture ()
-picture font = move 200 $ do
+makePicture :: FontData -> Picture ()
+makePicture font = move 200 $ do
     let text = withFont font $ withFill (solid white) $
                    letters 128 64 "Hello world!"
         textSize = pictureSize text
@@ -30,7 +30,6 @@ picture font = move 200 $ do
                                  , StrokeFill $ FillColor $ \(V2 x y) ->
                                        V4 (abs x/100) (abs y/100) 1 1
                                  ] $ rectangle textSize
-    -- let texFile = "gelatin-example" </> "assets" </> "tex.jpg"
     withFill (FillTexture jpgTex $ \v -> (100 + v) / 200) $ circle 100
     text
 
@@ -50,12 +49,8 @@ loop pic rez window cache = do
 
 main :: IO ()
 main = do
-    -- let fontFile = "gelatin-example" </> "assets" </> "Neuton-Regular.ttf"
-    -- eneuton <- getCurrentDirectory >>= loadFont . (</> fontFile)
-    let eneuton = fontyData <$> decodeFont (fromStrict ttfFont)
-    neuton <- case eneuton of
-        Left err -> do putStrLn err
-                       exitFailure
-        Right f -> return f
-    (rez, window) <- startupSDL2Backend 800 600 "gelatin" True
-    loop (picture neuton) rez window mempty
+    font <- case fontyData <$> decodeFont (fromStrict ttfFont) of
+                    Left err -> putStrLn err >> exitFailure
+                    Right f  -> return f
+    (rez, window) <- startupSDL2Backend 800 600 "gelatin-example" True
+    loop (makePicture font) rez window mempty

--- a/gelatin-example/src/Main.hs
+++ b/gelatin-example/src/Main.hs
@@ -4,6 +4,7 @@ import           Control.Concurrent     (threadDelay)
 import           Control.Monad          (when)
 import qualified Data.ByteString
 import           Data.ByteString.Lazy   (fromStrict)
+import           Data.FileEmbed         (embedFile)
 import           Graphics.Text.TrueType (decodeFont)
 import           SDL                    (EventPayload(QuitEvent))
 import           System.Directory       (getCurrentDirectory)
@@ -13,6 +14,10 @@ import           System.Exit            (exitSuccess, exitFailure)
 import           Data.Renderable
 import           Gelatin.SDL2
 
+
+ttfFont, jpgTex :: Data.ByteString.ByteString
+ttfFont = $(embedFile "./assets/Neuton-Regular.ttf")
+jpgTex  = $(embedFile "./assets/tex.jpg")
 
 picture :: FontData -> Picture ()
 picture font = move 200 $ do
@@ -25,8 +30,8 @@ picture font = move 200 $ do
                                  , StrokeFill $ FillColor $ \(V2 x y) ->
                                        V4 (abs x/100) (abs y/100) 1 1
                                  ] $ rectangle textSize
-    let texFile = "gelatin-example" </> "assets" </> "tex.jpg"
-    withFill (FillTexture texFile $ \v -> (100 + v) / 200) $ circle 100
+    -- let texFile = "gelatin-example" </> "assets" </> "tex.jpg"
+    withFill (FillTexture jpgTex $ \v -> (100 + v) / 200) $ circle 100
     text
 
 handleEvent :: Event -> IO ()
@@ -45,8 +50,9 @@ loop pic rez window cache = do
 
 main :: IO ()
 main = do
-    let fontFile = "gelatin-example" </> "assets" </> "Neuton-Regular.ttf"
-    eneuton <- getCurrentDirectory >>= loadFont . (</> fontFile)
+    -- let fontFile = "gelatin-example" </> "assets" </> "Neuton-Regular.ttf"
+    -- eneuton <- getCurrentDirectory >>= loadFont . (</> fontFile)
+    let eneuton = fontyData <$> decodeFont (fromStrict ttfFont)
     neuton <- case eneuton of
         Left err -> do putStrLn err
                        exitFailure

--- a/gelatin-gl/gelatin-gl.cabal
+++ b/gelatin-gl/gelatin-gl.cabal
@@ -29,6 +29,7 @@ library
                        Gelatin.GL.Primitives,
                        Gelatin.GL.Common
   build-depends:       base            >= 4.8     && < 4.9,
+                       bytestring,
                        gelatin-picture >= 0.0.0.1,
                        linear          >= 1.20    && < 1.21,
                        gl              >= 0.7     && < 0.8,


### PR DESCRIPTION
Okay, this one is more tricky. I made a `FillTextureFile` which does what `FillTexture` used to do. Now `FillTexture` is taking a `ByteString`.

I can not judge well if the `ByteString` apporach is a good one. I can also imagine its great to have `FillTexture` take a `DynamicImage` or even a `GLuint` (pointing to the texture in GL'istan).

Currently it compiles the example, for what that's worth. :)

This changes the API, so a version bump of `-gl` and `-core` is probably/officially needed. 